### PR TITLE
fix: remove illegal attributes for log alert monitors

### DIFF
--- a/terraform/monitors.tf
+++ b/terraform/monitors.tf
@@ -18,9 +18,7 @@ EOT
   thresholds {
     ok                = 0
     warning           = 4
-    warning_recovery  = 3
     critical          = 6
-    critical_recovery = 5
   }
 
   no_data_timeframe = 2
@@ -61,7 +59,6 @@ EOT
   thresholds {
     ok                = 0
     critical          = 1
-    critical_recovery = 0
   }
 
   no_data_timeframe = 2


### PR DESCRIPTION
Those attributes are not allowed for monitors of type "log alert" and cause the UI to fail when saving changes.